### PR TITLE
Fix newline truncation in COMMIT_MESSAGE and add newline before CREDITS

### DIFF
--- a/send.ps1
+++ b/send.ps1
@@ -38,14 +38,18 @@ if (!$env:APPVEYOR_REPO_COMMIT) {
 $AUTHOR_NAME="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%aN")"
 $COMMITTER_NAME="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%cN")"
 $COMMIT_SUBJECT="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%s")" -replace "`"", "'"
-$COMMIT_MESSAGE="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%b")" -replace "`"", "'"
+$COMMIT_MESSAGE=(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%b") -replace "`"", "'" | Out-String | ConvertTo-Json
 
 if ($AUTHOR_NAME -eq $COMMITTER_NAME) {
-  $CREDITS="$AUTHOR_NAME authored & committed"
+  $CREDITS="`n - $AUTHOR_NAME authored & committed" | ConvertTo-Json
 }
 else {
-  $CREDITS="$AUTHOR_NAME authored & $COMMITTER_NAME committed"
+  $CREDITS="`n - $AUTHOR_NAME authored & $COMMITTER_NAME committed" | ConvertTo-Json
 }
+
+#Remove Starting and Ending double quotes by ConvertTo-Json
+$COMMIT_MESSAGE = $COMMIT_MESSAGE.Substring(1, $COMMIT_MESSAGE.Length-2)
+$CREDITS = $CREDITS.Substring(1, $CREDITS.Length-2)
 
 if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
   $COMMIT_SUBJECT="PR #$env:APPVEYOR_PULL_REQUEST_NUMBER - $env:APPVEYOR_PULL_REQUEST_TITLE"

--- a/send.ps1
+++ b/send.ps1
@@ -41,13 +41,15 @@ $COMMIT_SUBJECT="$(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%s")" -repla
 $COMMIT_MESSAGE=(git log -1 "$env:APPVEYOR_REPO_COMMIT" --pretty="%b") -replace "`"", "'" | Out-String | ConvertTo-Json
 
 if ($AUTHOR_NAME -eq $COMMITTER_NAME) {
-  $CREDITS="`n - $AUTHOR_NAME authored & committed" | ConvertTo-Json
+  $CREDITS="`n$AUTHOR_NAME authored & committed" | ConvertTo-Json
+
 }
 else {
-  $CREDITS="`n - $AUTHOR_NAME authored & $COMMITTER_NAME committed" | ConvertTo-Json
+  $CREDITS="`n$AUTHOR_NAME authored & $COMMITTER_NAME committed" | ConvertTo-Json
+
 }
 
-#Remove Starting and Ending double quotes by ConvertTo-Json
+# Remove Starting and Ending double quotes by ConvertTo-Json
 $COMMIT_MESSAGE = $COMMIT_MESSAGE.Substring(1, $COMMIT_MESSAGE.Length-2)
 $CREDITS = $CREDITS.Substring(1, $CREDITS.Length-2)
 


### PR DESCRIPTION
1. Fixed newline truncation in COMMIT_MESSAGE and
2. Add newline before CREDITS in Discord Embed description.

Fixes issue #15 

Original Commit: https://github.com/ShootingKing-AM/PhoneVR/commit/0b24f931dc1172f12a31c578ac8146dc2a60f541

**Before Fix:**
<img style="float:top" src="https://user-images.githubusercontent.com/4137788/100535983-904b8c80-3243-11eb-812f-8033e0c5d860.jpg" width=80%/>

 **After Fix:**
<img src="https://user-images.githubusercontent.com/4137788/100535989-9477aa00-3243-11eb-8992-287360f0287d.jpg" width=80%/>
