### PR TITLE
Remove username to Discord payload

### DIFF
--- a/send.ps1
+++ b/send.ps1
@@ -64,7 +64,6 @@ else {
 $BUILD_VERSION = [uri]::EscapeDataString($env:APPVEYOR_BUILD_VERSION)
 $TIMESTAMP="$(Get-Date -format s)Z"
 $WEBHOOK_DATA="{
-  ""username"": ""$AUTHOR_NAME"",
   ""avatar_url"": ""$AVATAR"",
   ""embeds"": [ {
     ""color"": $EMBED_COLOR,

--- a/send.ps1
+++ b/send.ps1
@@ -64,7 +64,7 @@ else {
 $BUILD_VERSION = [uri]::EscapeDataString($env:APPVEYOR_BUILD_VERSION)
 $TIMESTAMP="$(Get-Date -format s)Z"
 $WEBHOOK_DATA="{
-  ""username"": """",
+  ""username"": ""$AUTHOR_NAME"",
   ""avatar_url"": ""$AVATAR"",
   ""embeds"": [ {
     ""color"": $EMBED_COLOR,


### PR DESCRIPTION
Coming back to a project using this webhook after a while; I started getting an error that the `username` value in the Discord payload could not be empty. I updated it in my local copy to use the `$AUTHOR_NAME` variable and it seems to work fine now. :)